### PR TITLE
feat: add dependabot configuration for NuGet dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: "direct"
+    commit-message:
+      prefix: "chore(deps):"
+    pull-request-branch-name:
+      separator: "/"

--- a/src/Bounteous.Data.Sample/Bounteous.Data.Sample.csproj
+++ b/src/Bounteous.Data.Sample/Bounteous.Data.Sample.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Bounteous.Core" Version="0.0.19" />
+        <PackageReference Include="Bounteous.Core" Version="0.0.20" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.5" />

--- a/src/Bounteous.Data.Tests/Bounteous.Data.Tests.csproj
+++ b/src/Bounteous.Data.Tests/Bounteous.Data.Tests.csproj
@@ -11,14 +11,14 @@
 
     <ItemGroup>
         <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
-        <PackageReference Include="Bounteous.Core" Version="0.0.19" />
-        <PackageReference Include="coverlet.collector" Version="8.0.0">
+        <PackageReference Include="Bounteous.Core" Version="0.0.20" />
+        <PackageReference Include="coverlet.collector" Version="8.0.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/src/Bounteous.Data/Bounteous.Data.csproj
+++ b/src/Bounteous.Data/Bounteous.Data.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Bounteous.Core" Version="0.0.19" />
+      <PackageReference Include="Bounteous.Core" Version="0.0.20" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
         <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Changes
- Add `.github/dependabot.yml` configuration for automated NuGet dependency updates

## Why
- Automates dependency version updates as upstream Bounteous modules are published
- Reduces manual version management across dependent modules
- Creates PRs automatically that respect the existing approval workflow

## Workflow
When Bounteous.Core publishes a new version, Dependabot will:
1. Detect the new version on NuGet
2. Create a PR with the updated reference
3. Run existing CI/CD tests automatically
4. Await PR review before merge